### PR TITLE
Scheme and domain based routing. Also, changes as per issue#6. WIP

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,21 +2,8 @@ using Endpoints, Base.Test, HTTP
 
 include("json2.jl")
 
-Endpoints.@GET (@__MODULE__) "test" ()->"testing GET resource"
-Endpoints.@GET @__MODULE__ "test/{var::String}" var->"testing $var resource"
-Endpoints.@GET @__MODULE__ "test/int/{var::Int}" var->"testing int $var resource"
-Endpoints.@GET @__MODULE__ "test/type/{::Type{T}}" T->parse(T, "1")
-# Issue #2
-path = "/test/dynamic/path"
-Endpoints.@GET path ()->"testing path from variable"
-
-type Bod
-    id::Int
-    nm::String
-end
-
-Endpoints.@POST "test/post" body body->"do you like my $body"
-Endpoints.@POST "test/post/andarg/{arg}" body (arg, body)->"do you like my $arg and $body"
-Endpoints.@POST "test/post/typedbod" body::Bod bod->"nice bod: $(bod.id), $(bod.nm)"
+Endpoints.@GET "/just/resource" ()->"testing just resource"
+Endpoints.@GET "http://www.google.com/domain/and/resource" ()->"testing scheme and domain routing"
+Endpoints.@GET "www.google.com/just/domain" ()->"testing just domain routing"
 
 HTTP.serve(handler = Endpoints.handler)


### PR DESCRIPTION
This is a very raw implementation of scheme and host based routing. It has many issues like:
 

1. It doesn't support variables in the URL like `/test/var{:Int}`
2. Would fail the same corner cases as the simple routing does (issue 4)
3. It doesn't handle the case when two routing conditions have same routes but different scheme and/or host. This is due to the approach used. To correct this we have to check for all the routing conditions that have same matching routes ( I but don't know how ) a. e.g of failing condition:
```julia
Endpoints.@GET "test/host" ()->"testing gmail routing" Dict("host"=>"www.gmail.com")
Endpoints.@GET "test/host" ()->"testing google host routing" Dict("host"=>"www.google.com")
```  
If one browses www.google.com/test/host for the above example (point 3) it will only check the first host condition ([here](https://github.com/quinnj/Endpoints.jl/blob/sarv/scheme/src/Endpoints.jl#L183)), and would miss the second condition which is correct so it return `status 404`. 

The aim of this pull request is to get your opinion on my current approach. Also,  if you have some other idea please suggest that because this doesn't seem correct and clean. 