### PR TITLE
Fix issue#4

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ Endpoints.@GET "test" ()->"testing GET resource"
 Endpoints.@GET "test/{var::String}" var->"testing $var resource"
 Endpoints.@GET "test/int/{var::Int}" var->"testing int $var resource"
 Endpoints.@GET "test/type/{::Type{T}}" T->parse(T, "1")
+Endpoints.@GET "test/sarv/ghotra" ()->"testing sarv ghotra conflict case"
 
 type Bod
     id::Int
@@ -16,4 +17,8 @@ Endpoints.@POST "test/post" body body->"do you like my $body"
 Endpoints.@POST "test/post/andarg/{arg}" body (arg, body)->"do you like my $arg and $body"
 Endpoints.@POST "test/post/typedbod" body::Bod bod->"nice bod: $(bod.id), $(bod.nm)"
 
-HTTP.serve(handler = Endpoints.handler)
+@async HTTP.serve(handler = Endpoints.handler)
+
+# issue 4
+res_body = String(take!(HTTP.get("http://localhost:8081/test/sarv")))
+@test res_body == "\"testing sarv resource\""


### PR DESCRIPTION
[issue#4](https://github.com/quinnj/Endpoints.jl/issues/4)
Matches the `request` against all the registered routes in `PATH_TABLE`. It also matches for `scheme` and `domain` conditions. It works fine for the conflicting situation mentioned in issue#4.

But I am little confused for the following case:
```julia
Endpoints.@GET "test/type/{::Type{T}}" T->parse(T, "1")
```
For a request at `test/type/go`, it returns `test/type/go` (i.e nothing found). I am not sure if its correct behaviour. @quinnj can you please help here.

Also, it is one commit behind the master that is because the last commit doesn't work. I have mentioned this problem in issue#2 (reopened).